### PR TITLE
feat: add optional `log` feature for warning on resolution failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,6 +2914,7 @@ version = "0.2.0"
 dependencies = [
  "aws-sdk-s3",
  "http-cache-reqwest",
+ "log",
  "mockito",
  "moka",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ moka = { version = "0.12", default-features = false, features = ["sync"], option
 reqwest = { version = "0.12.9", default-features = false, optional = true }
 reqwest-middleware = { version = "0.4", optional = true }
 tokio = { version = "1.43.1", default-features = false, optional = true, features = ["rt", "rt-multi-thread"] }
+log = { version = "0.4", optional = true }
 usvg = "0.47.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,16 @@ pub trait HrefStringResolver<'a>: Send + Sync {
     {
         Box::new(move |href, options| {
             if self.is_target(href) {
-                self.get_image_kind(href, options)
+                let result = self.get_image_kind(href, options);
+                if result.is_none() {
+                    crate::utils::log_warn!("failed to resolve image href: '{}'", href);
+                }
+                result
             } else {
+                crate::utils::log_warn!(
+                    "image href '{}' is not a target for this resolver",
+                    href
+                );
                 None
             }
         })

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -37,18 +37,44 @@ impl HrefStringResolver<'_> for ReqwestResolver {
         let href = href.to_string();
         // Check if we're already in a tokio runtime
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            crate::utils::log_warn!(
+                "no tokio runtime found; cannot resolve '{}'",
+                href
+            );
             return None;
         };
         // We're in an async context, use block_in_place
         let (image_type, body) = tokio::task::block_in_place(|| {
             handle.block_on(async {
-                let resp = client.get(&href).send().await.ok()?;
+                let resp = match client.get(&href).send().await {
+                    Ok(resp) => resp,
+                    Err(e) => {
+                        crate::utils::log_warn!("failed to fetch '{}': {}", href, e);
+                        return None;
+                    }
+                };
                 let content_type = resp
                     .headers()
                     .get(reqwest::header::CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok());
-                let image_type = crate::utils::ImageKindTypes::get_image_type(content_type, &href)?;
-                let body = resp.bytes().await.ok()?.to_vec();
+                let image_type = match crate::utils::ImageKindTypes::get_image_type(content_type, &href) {
+                    Some(t) => t,
+                    None => {
+                        crate::utils::log_warn!(
+                            "unsupported image type for '{}' (content-type: {:?})",
+                            href,
+                            content_type
+                        );
+                        return None;
+                    }
+                };
+                let body = match resp.bytes().await {
+                    Ok(b) => b.to_vec(),
+                    Err(e) => {
+                        crate::utils::log_warn!("failed to read response body for '{}': {}", href, e);
+                        return None;
+                    }
+                };
                 Some((image_type, body))
             })
         })?;

--- a/src/reqwest_blocking.rs
+++ b/src/reqwest_blocking.rs
@@ -34,13 +34,35 @@ impl HrefStringResolver<'_> for BlockingReqwestResolver {
         crate::utils::is_remote_url(href)
     }
     fn get_image_kind(&self, href: &str, options: &usvg::Options) -> Option<usvg::ImageKind> {
-        let resp = self.client.get(href).send().ok()?;
+        let resp = match self.client.get(href).send() {
+            Ok(resp) => resp,
+            Err(e) => {
+                crate::utils::log_warn!("failed to fetch '{}': {}", href, e);
+                return None;
+            }
+        };
         let content_type = resp
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok());
-        let image_type = ImageKindTypes::get_image_type(content_type, href)?;
-        let body = resp.bytes().ok()?.to_vec();
+        let image_type = match ImageKindTypes::get_image_type(content_type, href) {
+            Some(t) => t,
+            None => {
+                crate::utils::log_warn!(
+                    "unsupported image type for '{}' (content-type: {:?})",
+                    href,
+                    content_type
+                );
+                return None;
+            }
+        };
+        let body = match resp.bytes() {
+            Ok(b) => b.to_vec(),
+            Err(e) => {
+                crate::utils::log_warn!("failed to read response body for '{}': {}", href, e);
+                return None;
+            }
+        };
         image_type.into_image_kind(body.into(), options)
     }
 }

--- a/src/reqwest_http_cache.rs
+++ b/src/reqwest_http_cache.rs
@@ -71,17 +71,43 @@ impl HrefStringResolver<'_> for HttpCacheReqwestResolver {
         let client = self.client.clone();
         let href = href.to_string();
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            crate::utils::log_warn!(
+                "no tokio runtime found; cannot resolve '{}'",
+                href
+            );
             return None;
         };
         let (image_type, body) = tokio::task::block_in_place(|| {
             handle.block_on(async {
-                let resp = client.get(&href).send().await.ok()?;
+                let resp = match client.get(&href).send().await {
+                    Ok(resp) => resp,
+                    Err(e) => {
+                        crate::utils::log_warn!("failed to fetch '{}': {}", href, e);
+                        return None;
+                    }
+                };
                 let content_type = resp
                     .headers()
                     .get(reqwest::header::CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok());
-                let image_type = crate::utils::ImageKindTypes::get_image_type(content_type, &href)?;
-                let body = resp.bytes().await.ok()?.to_vec();
+                let image_type = match crate::utils::ImageKindTypes::get_image_type(content_type, &href) {
+                    Some(t) => t,
+                    None => {
+                        crate::utils::log_warn!(
+                            "unsupported image type for '{}' (content-type: {:?})",
+                            href,
+                            content_type
+                        );
+                        return None;
+                    }
+                };
+                let body = match resp.bytes().await {
+                    Ok(b) => b.to_vec(),
+                    Err(e) => {
+                        crate::utils::log_warn!("failed to read response body for '{}': {}", href, e);
+                        return None;
+                    }
+                };
                 Some((image_type, body))
             })
         })?;

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -156,13 +156,20 @@ impl<C: S3CacheStore> HrefStringResolver<'_> for CachedS3Resolver<C> {
         is_s3_url(href)
     }
     fn get_image_kind(&self, href: &str, options: &usvg::Options) -> Option<usvg::ImageKind> {
-        let (bucket, key) = parse_s3_url(href)?;
+        let Some((bucket, key)) = parse_s3_url(href) else {
+            crate::utils::log_warn!("invalid S3 URL: '{}'", href);
+            return None;
+        };
         let client = self.client.clone();
         let bucket = bucket.to_string();
         let key = key.to_string();
         let cached = self.cache.get(href);
 
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            crate::utils::log_warn!(
+                "no tokio runtime found; cannot resolve '{}'",
+                href
+            );
             return None;
         };
 
@@ -177,12 +184,31 @@ impl<C: S3CacheStore> HrefStringResolver<'_> for CachedS3Resolver<C> {
                     Ok(resp) => {
                         let etag = resp.e_tag().unwrap_or_default().to_string();
                         let content_type = resp.content_type().map(|s| s.to_string());
-                        let image_type = crate::utils::ImageKindTypes::get_image_type(
+                        let image_type = match crate::utils::ImageKindTypes::get_image_type(
                             content_type.as_deref(),
                             &key,
-                        )?;
-                        let body: Arc<Vec<u8>> =
-                            Arc::new(resp.body.collect().await.ok()?.to_vec());
+                        ) {
+                            Some(t) => t,
+                            None => {
+                                crate::utils::log_warn!(
+                                    "unsupported image type for '{}' (content-type: {:?})",
+                                    href,
+                                    content_type
+                                );
+                                return None;
+                            }
+                        };
+                        let body: Arc<Vec<u8>> = match resp.body.collect().await {
+                            Ok(b) => Arc::new(b.to_vec()),
+                            Err(e) => {
+                                crate::utils::log_warn!(
+                                    "failed to read S3 response body for '{}': {}",
+                                    href,
+                                    e
+                                );
+                                return None;
+                            }
+                        };
 
                         if !etag.is_empty() {
                             self.cache.put(
@@ -199,8 +225,8 @@ impl<C: S3CacheStore> HrefStringResolver<'_> for CachedS3Resolver<C> {
                     }
                     Err(err) => {
                         // 304 Not Modified — use cached entry
-                        let raw = err.raw_response()?;
-                        if raw.status().as_u16() == 304 {
+                        let raw = err.raw_response();
+                        if raw.as_ref().is_some_and(|r| r.status().as_u16() == 304) {
                             let cached = cached?;
                             let image_type = crate::utils::ImageKindTypes::get_image_type(
                                 cached.content_type.as_deref(),
@@ -208,6 +234,11 @@ impl<C: S3CacheStore> HrefStringResolver<'_> for CachedS3Resolver<C> {
                             )?;
                             Some((image_type, cached.body))
                         } else {
+                            crate::utils::log_warn!(
+                                "S3 request failed for '{}': {}",
+                                href,
+                                err
+                            );
                             None
                         }
                     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,15 @@
 use std::sync::Arc;
 
+macro_rules! log_warn {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "log")]
+        log::warn!($($arg)*);
+        #[cfg(not(feature = "log"))]
+        { let _ = format_args!($($arg)*); }
+    };
+}
+pub(crate) use log_warn;
+
 /// Check if the `href` is a remote URL (http or https).
 pub fn is_remote_url(href: &str) -> bool {
     href.starts_with("https://") || href.starts_with("http://")


### PR DESCRIPTION
All resolvers now emit `log::warn!` when image resolution fails (network errors, unsupported content-type, missing tokio runtime, etc.) instead of silently returning None. The logging is behind an optional `log` feature flag to avoid adding a mandatory dependency.